### PR TITLE
fix(fancy-badge): adjust button width on mobile screens

### DIFF
--- a/apps/web/src/components/ui/fancy-badges.tsx
+++ b/apps/web/src/components/ui/fancy-badges.tsx
@@ -4,7 +4,7 @@ const FancyBadgeWithBorders = ({ children }: { children: string }) => {
   return (
     <div className="flex flex-row items-center gap-2 px-6">
       <div className="flex flex-row items-center">
-        <div className="from-muted h-px w-24 bg-gradient-to-l to-transparent sm:w-40"></div>
+        <div className="from-muted h-px w-20 bg-gradient-to-l to-transparent sm:w-40"></div>
         <div className="bg-muted/20 h-1.5 w-1.5 border"></div>
       </div>
       <div className="bg-muted/20 jetbrains-mono relative flex h-7 flex-row items-center gap-2 rounded-md border px-4 text-sm font-medium">
@@ -12,7 +12,7 @@ const FancyBadgeWithBorders = ({ children }: { children: string }) => {
       </div>
       <div className="flex flex-row items-center">
         <div className="bg-muted/20 h-1.5 w-1.5 border"></div>
-        <div className="from-muted h-px w-24 bg-gradient-to-r to-transparent sm:w-40"></div>
+        <div className="from-muted h-px w-20 bg-gradient-to-r to-transparent sm:w-40"></div>
       </div>
     </div>
   );


### PR DESCRIPTION
<img width="499" height="636" alt="Screenshot 2025-09-07 090234" src="https://github.com/user-attachments/assets/17ef21fc-6d73-4664-a0a0-bc79e69df657" />

## What’s Changed
- Fixed button width issue in FancyBadge component on mobile screens.

## Before
w-24 

## After
w-20
