### PR TITLE
fix: Optional Badge Text Visibility in Light Mode

### DIFF
--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -10,7 +10,7 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: "dark:bg-primary/10 dark:text-primary bg-primary text-white",
-        secondary: "dark:bg-secondary/80 dark:text-secondary-foreground text-white bg-secondary",
+        secondary: "dark:bg-secondary/80 dark:text-secondary-foreground text-black bg-secondary",
         destructive: "dark:bg-red-500/10 dark:text-red-500 text-white bg-red-500",
         outline: "text-foreground border",
         green: "dark:bg-green-500/10 text-white dark:text-green-500 bg-green-500",


### PR DESCRIPTION
This PR fixes an issue where the option badge text was not visible in light mode due to the text-white class being applied by default. The text blended into the light background, making it unreadable.

✅ Changes Made
Removed the text-white class from the secondary variant of the badge to ensure proper contrast in light mode.

<table> <tr> <td><strong>Before</strong></td> <td><strong>After</strong></td> </tr> <tr> <td> <img width="300" alt="Before" src="https://github.com/user-attachments/assets/3ce1abcc-680b-4e27-8ca8-4c88561eaf40" /> </td> <td> <img width="300" alt="After" src="https://github.com/user-attachments/assets/bc752b84-3bc0-490b-82fc-4e5142b260b0" /> </td> </tr> </table>

Fixes: #46 