### PR TITLE
Fix default status value in UpdateStatusModal for saved invoices

### DIFF
--- a/apps/web/src/components/table-columns/invoices/index.tsx
+++ b/apps/web/src/components/table-columns/invoices/index.tsx
@@ -127,7 +127,7 @@ export const columns = [
     id: "actions",
     header: ({ column }) => <HeaderColumnButton column={column}>Actions</HeaderColumnButton>,
     cell: ({ row }) => {
-      const { id, type } = row.original;
+      const { id, type, status } = row.original;
 
       return (
         <div key={id} className="flex flex-row items-center gap-2">
@@ -138,7 +138,7 @@ export const columns = [
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <UpdateStatusModal invoiceId={id} type={type} />
+              <UpdateStatusModal invoiceId={id} type={type} currentStatus={status} />
               <Link href={`/edit/${type}/${id}`}>
                 <DropdownMenuItem>
                   <FilePenIcon />

--- a/apps/web/src/components/table-columns/invoices/updateStatusModal.tsx
+++ b/apps/web/src/components/table-columns/invoices/updateStatusModal.tsx
@@ -44,6 +44,7 @@ import { z } from "zod";
 interface UpdateStatusModalProps {
   type: InvoiceTypeType;
   invoiceId: string;
+  currentStatus: string;
 }
 
 const invoiceStatusSchema = z.object({
@@ -53,7 +54,7 @@ const invoiceStatusSchema = z.object({
 
 type InvoiceStatusSchema = z.infer<typeof invoiceStatusSchema>;
 
-const UpdateStatusModal = ({ invoiceId, type }: UpdateStatusModalProps) => {
+const UpdateStatusModal = ({ invoiceId, type, currentStatus }: UpdateStatusModalProps) => {
   const [open, setOpen] = useState(false);
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -97,7 +98,7 @@ const UpdateStatusModal = ({ invoiceId, type }: UpdateStatusModalProps) => {
     resolver: zodResolver(invoiceStatusSchema),
     defaultValues: {
       id: invoiceId,
-      status: "pending",
+      status: currentStatus as (typeof invoiceStatusEnum.enumValues)[number],
     },
   });
 


### PR DESCRIPTION
### Description
This PR fixes an issue where the `UpdateStatusModal` dialog box in the invoices page did not display the existing status of an invoice as the default value when updating the status of a locally saved invoice. 

### Changes
- Ensured that the `currentStatus` prop is passed correctly to the form's default values.
- Verified that the default value reflects the existing status of the invoice.

fixes: #55