### PR TITLE
fix: prevent text wrapping in FancyBadgeWithBorders on small screens  #58

### DIFF
--- a/apps/web/src/components/ui/fancy-badges.tsx
+++ b/apps/web/src/components/ui/fancy-badges.tsx
@@ -7,7 +7,7 @@ const FancyBadgeWithBorders = ({ children }: { children: string }) => {
         <div className="from-muted h-px w-20 bg-gradient-to-l to-transparent sm:w-40"></div>
         <div className="bg-muted/20 h-1.5 w-1.5 border"></div>
       </div>
-      <div className="bg-muted/20 jetbrains-mono relative flex h-7 flex-row items-center gap-2 rounded-md border px-4 text-sm font-medium">
+      <div className="bg-muted/20 jetbrains-mono relative flex h-7 flex-row items-center whitespace-nowrap gap-2 rounded-md border px-4 text-sm font-medium">
         <span>{children}</span>
       </div>
       <div className="flex flex-row items-center">


### PR DESCRIPTION
Description
This PR fixes an issue where "Our Sponsor" header badge experiencing text wrapping issues on small screens, causing the decorative borders and dots to misalign with the badge text.

Fixed alignment:
<img width="246" height="448" alt="image" src="https://github.com/user-attachments/assets/c7e3b828-e146-4a21-aef5-8353178bc3de" />


Changes
Add `whitespace-nowrap` to the badge div's className to prevent text wrapping and maintain consistent alignment across all screen sizes.

Impact
- ✅ Fixes alignment issue on mobile devices
- ✅ Improves visual consistency across all screen sizes
- ✅ Maintains the intended design aesthetic

fixes: https://github.com/legions-developer/invoicely/issues/58