### PR TITLE
fix: implement responsive signature canvas sizing for all screens  

### DIFF
--- a/apps/web/src/components/ui/image/signature-input-modal.tsx
+++ b/apps/web/src/components/ui/image/signature-input-modal.tsx
@@ -278,8 +278,9 @@ export default function SignatureInputModal({
                 onBegin={() => setIsSignatureEmpty(false)}
                 penColor={darkMode ? "white" : "black"}
                 backgroundColor={darkMode ? "#181818" : "#ffffff"}
-                canvasProps={{ width: 330, height: 330, className: "signature-canvas" }}
-              />
+                canvasProps={{ 
+                  className: "signature-canvas w-full h-full max-w-[330px] max-h-[330px] min-w-[200px] min-h-[200px] aspect-square" 
+                }}              />
             </div>
           </DialogContentContainer>
           <DialogFooter>


### PR DESCRIPTION
## Problem
The signature canvas in the signature input modal has fixed dimensions (330x330px) which causes:
- Overflow on small screens

## Current Behavior
<img width="243" height="450" alt="image" src="https://github.com/user-attachments/assets/fab20052-edc1-45ae-bc32-01a411abed12" />

## After Fixed Behavior
<img width="242" height="449" alt="image" src="https://github.com/user-attachments/assets/e43b76f4-c549-402c-9300-646d0243c673" />


## Changes Made
- Removed one fixed width/height from canvas props
- Added responsive CSS classes with min/max constraints for small and larger screens
- Updated container styling for better responsive behavior
- Maintained aspect-square ratio for consistent signature quality

