### PR TITLE
fix: increase unit_price decimal precision from 2 to 4 (closes #66)

### DIFF
--- a/packages/db/src/schema/invoice.ts
+++ b/packages/db/src/schema/invoice.ts
@@ -106,7 +106,7 @@ export const invoiceItems = pgTable("invoice_items", {
   name: text("name").notNull(),
   description: text("description").notNull(),
   quantity: integer("quantity").notNull(),
-  unitPrice: Numeric("unit_price", { precision: 10, scale: 2 }).notNull(),
+  unitPrice: Numeric("unit_price", { precision: 10, scale: 4 }).notNull(),
   invoiceFieldId: uuid("invoice_field_id")
     .references(() => invoiceFields.id, { onDelete: "cascade" })
     .notNull(),


### PR DESCRIPTION
## Summary

Fixes #66 — unit price loses decimal precision when saved to database.

### Problem
The `unit_price` column uses `NUMERIC(10,2)`, which truncates anything beyond 2 decimal places. Setting a unit price of `0.141` saves as `0.14`.

### Fix
Changed `scale` from `2` to `4` in the schema definition: `NUMERIC(10,4)`.

This supports up to 4 decimal places (e.g., `0.0375` for per-unit energy costs) while keeping existing 2-decimal data unaffected.

### Files Changed
- `packages/db/src/schema/invoice.ts` — `unitPrice` column scale: 2 → 4

### Note
A database migration will be needed to alter the existing column for deployed instances.