### PR TITLE
feat: implement reorder functionality for invoice items

### DIFF
--- a/apps/web/src/app/(dashboard)/create/invoice/invoiceHelpers/invoice-items-section.tsx
+++ b/apps/web/src/app/(dashboard)/create/invoice/invoiceHelpers/invoice-items-section.tsx
@@ -16,13 +16,14 @@ import {
 import { createInvoiceItemSchema, ZodCreateInvoiceSchema } from "@/zod-schemas/invoice/create-invoice";
 import { useFieldArray, useForm, UseFormReturn } from "react-hook-form";
 import { BoxIcon, BoxPlusIcon, TrashIcon } from "@/assets/icons";
+import { Reorder } from "motion/react";
 import { FormInput } from "@/components/ui/form/form-input";
 import { formatCurrencyText } from "@/constants/currency";
 import { zodResolver } from "@hookform/resolvers/zod";
 import FormRow from "@/components/ui/form/form-row";
 import { Form } from "@/components/ui/form/form";
 import { Button } from "@/components/ui/button";
-import { PencilIcon } from "lucide-react";
+import { GripVerticalIcon, PencilIcon } from "lucide-react";
 import React, { useState } from "react";
 
 interface InvoiceItemsSectionProps {
@@ -31,19 +32,37 @@ interface InvoiceItemsSectionProps {
 type InvoiceItem = ZodCreateInvoiceSchema["items"][number];
 
 const InvoiceItemsSection: React.FC<InvoiceItemsSectionProps> = ({ form }) => {
-  const { fields, append, remove, update } = useFieldArray({
+  const { fields, append, remove, update, move } = useFieldArray({
     control: form.control,
     name: "items",
   });
+
+  const onReorder = (newIds: string[]) => {
+    const oldIds = fields.map((field) => field.id);
+    const reorder = getSingleMove(oldIds, newIds);
+    if (reorder) move(reorder.from, reorder.to);
+  };
 
   return (
     <div className="flex flex-col gap-2">
       {/* Rendering the items */}
       {fields.length > 0 && (
-        <div className="flex flex-col gap-2">
+        <Reorder.Group
+          axis="y"
+          values={fields.map((field) => field.id)}
+          onReorder={onReorder}
+          className="flex flex-col gap-2"
+        >
           {fields.map((field, index) => (
-            <div className="bg-muted/50 flex w-full flex-row justify-between gap-2 rounded-md p-3" key={field.id}>
+            <Reorder.Item
+              value={field.id}
+              key={field.id}
+              className="bg-muted/50 flex w-full cursor-grab flex-row justify-between gap-2 rounded-md p-3 active:cursor-grabbing"
+            >
               <div className="flex w-full flex-row gap-2">
+                <div className="text-muted-foreground grid h-full place-items-center">
+                  <GripVerticalIcon className="size-4" />
+                </div>
                 <div className="bg-muted-foreground/20 grid aspect-square h-full place-items-center rounded-md">
                   <BoxIcon />
                 </div>
@@ -88,9 +107,9 @@ const InvoiceItemsSection: React.FC<InvoiceItemsSectionProps> = ({ form }) => {
                   </div>
                 </div>
               </div>
-            </div>
+            </Reorder.Item>
           ))}
-        </div>
+        </Reorder.Group>
       )}
       {/* Dialog for adding a new item */}
       <HandleItemModal type="add" append={append} update={update}>
@@ -104,6 +123,20 @@ const InvoiceItemsSection: React.FC<InvoiceItemsSectionProps> = ({ form }) => {
 };
 
 export default InvoiceItemsSection;
+
+// Derives a single move(from, to) from the old vs new id ordering produced by a drag.
+const getSingleMove = (oldIds: string[], newIds: string[]): { from: number; to: number } | null => {
+  let start = 0;
+  while (start < oldIds.length && oldIds[start] === newIds[start]) start++;
+
+  let end = oldIds.length - 1;
+  while (end >= 0 && oldIds[end] === newIds[end]) end--;
+
+  if (start > end) return null;
+
+  // Forward move if the element at `start` slid down to `end`, otherwise backward.
+  return oldIds[start] === newIds[end] ? { from: start, to: end } : { from: end, to: start };
+};
 
 interface AddItemModalProps {
   type: "add" | "edit";


### PR DESCRIPTION
This pull request adds drag-and-drop reordering functionality to the invoice items section, allowing users to rearrange invoice items interactively. It uses the `motion` library's `Reorder` components and updates the UI to include a drag handle icon. The code also introduces a helper function to efficiently determine the moved item during a reorder operation.

**Invoice item reordering functionality:**

* Integrated `Reorder.Group` and `Reorder.Item` from the `motion` library to enable drag-and-drop reordering of invoice items in the UI (`invoice-items-section.tsx`). [[1]](diffhunk://#diff-4849571c242fb215d5fda57557351ec94fa0c3741f3d38efbe42ad7587e627bbR19-R26) [[2]](diffhunk://#diff-4849571c242fb215d5fda57557351ec94fa0c3741f3d38efbe42ad7587e627bbL34-R65) [[3]](diffhunk://#diff-4849571c242fb215d5fda57557351ec94fa0c3741f3d38efbe42ad7587e627bbL91-R112)
* Added a drag handle (`GripVerticalIcon`) to each invoice item for improved user experience during reordering (`invoice-items-section.tsx`). [[1]](diffhunk://#diff-4849571c242fb215d5fda57557351ec94fa0c3741f3d38efbe42ad7587e627bbR19-R26) [[2]](diffhunk://#diff-4849571c242fb215d5fda57557351ec94fa0c3741f3d38efbe42ad7587e627bbL34-R65)
* Implemented the `onReorder` handler and a helper function `getSingleMove` to compute and apply the correct item movement in the form state (`invoice-items-section.tsx`). [[1]](diffhunk://#diff-4849571c242fb215d5fda57557351ec94fa0c3741f3d38efbe42ad7587e627bbL34-R65) [[2]](diffhunk://#diff-4849571c242fb215d5fda57557351ec94fa0c3741f3d38efbe42ad7587e627bbR127-R140)

<img width="1142" height="338" alt="image" src="https://github.com/user-attachments/assets/52f3d486-48d1-46d2-b7ae-113e8f2504a4" />


Closes #71 