### PR TITLE
feat(invoices): display invoice date column in invoices table

### DIFF
--- a/apps/web/src/components/table-columns/invoices/index.tsx
+++ b/apps/web/src/components/table-columns/invoices/index.tsx
@@ -11,6 +11,7 @@ import {
   HourglassStartIcon,
   IdBadgeIcon,
   PriorityMediumIcon,
+  ReceiptIcon,
   SortNumDescendingIcon,
 } from "@/assets/icons";
 import {
@@ -110,6 +111,12 @@ export const columns = [
     enableSorting: false,
   }),
 
+  columnHelper.accessor((row) => row.invoiceFields.invoiceDetails.date, {
+    id: "invoiceDate",
+    header: ({ column }) => <HeaderColumnButton column={column}>Invoice Date</HeaderColumnButton>,
+    cell: ({ row }) => <FormatTableDateObject date={row.original.invoiceFields.invoiceDetails.date} />,
+  }),
+
   columnHelper.accessor((row) => row.createdAt, {
     id: "createdAt",
     header: ({ column }) => <HeaderColumnButton column={column}>Created At</HeaderColumnButton>,
@@ -207,6 +214,12 @@ export const importInvoiceColumns = [
     ),
   }),
 
+  columnHelper.accessor((row) => row.invoiceFields.invoiceDetails.date, {
+    id: "invoiceDate",
+    header: ({ column }) => <HeaderColumnButton column={column}>Invoice Date</HeaderColumnButton>,
+    cell: ({ row }) => <FormatTableDateObject date={row.original.invoiceFields.invoiceDetails.date} />,
+  }),
+
   columnHelper.accessor((row) => row.createdAt, {
     id: "createdAt",
     header: ({ column }) => <HeaderColumnButton column={column}>Created At</HeaderColumnButton>,
@@ -234,6 +247,14 @@ export const columnConfig = [
     .displayName("ID")
     .accessor((row) => row.id)
     .icon(IdBadgeIcon)
+    .build(),
+  // Invoice Date
+  columnConfigHelper
+    .date()
+    .id("invoiceDate")
+    .displayName("Invoice Date")
+    .accessor((row) => row.invoiceFields.invoiceDetails.date)
+    .icon(ReceiptIcon)
     .build(),
   // Created At
   columnConfigHelper
@@ -296,6 +317,14 @@ export const importInvoiceColumnConfig = [
     .displayName("ID")
     .accessor((row) => row.id)
     .icon(IdBadgeIcon)
+    .build(),
+  // Invoice Date
+  columnConfigHelper
+    .date()
+    .id("invoiceDate")
+    .displayName("Invoice Date")
+    .accessor((row) => row.invoiceFields.invoiceDetails.date)
+    .icon(ReceiptIcon)
     .build(),
   // Created At
   columnConfigHelper


### PR DESCRIPTION
## Summary

Closes #64.

The invoices table only showed **Created At** (the row's creation timestamp). As requested in the issue, the invoice's own **Invoice Date** is the more meaningful parameter, so this surfaces it as a dedicated column placed just before **Created At**.

- Adds an `Invoice Date` column (sourced from `invoiceFields.invoiceDetails.date`) to both the main invoices table and the import-invoices table.
- Adds the matching date filter config so the column is filterable/sortable like the other date columns.
- Reuses the existing `FormatTableDateObject` renderer for consistency with `Created At` / `Paid At`.

## Test plan

- [ ] Open the invoices dashboard and confirm the new **Invoice Date** column appears before **Created At** for both local and server invoices.
- [ ] Confirm the value matches each invoice's selected date.
- [ ] Confirm the **Invoice Date** filter works in the data-table filter dropdown.
- [ ] Confirm the import-invoices flow shows the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)