### PR TITLE
feat(pdf): paginate long invoices and show all pages in preview

### DIFF
--- a/apps/web/src/app/(dashboard)/create/invoice/invoice-preview.tsx
+++ b/apps/web/src/app/(dashboard)/create/invoice/invoice-preview.tsx
@@ -25,6 +25,7 @@ const PDF_VIEWER_PADDING = 18;
 // Custom PDF viewer component that handles displaying a PDF document
 const PDFViewer = ({ url, width }: { url: string | null; width: number }) => {
   const [error, setError] = useState<Error | null>(null);
+  const [numPages, setNumPages] = useState(0);
 
   if (width === 0) {
     // setting width to 600px Because the container is not mounted yet
@@ -36,11 +37,17 @@ const PDFViewer = ({ url, width }: { url: string | null; width: number }) => {
     return null;
   }
 
+  const pageWidth = width > 600 ? 600 - PDF_VIEWER_PADDING : width - PDF_VIEWER_PADDING;
+
   return (
-    <div className="flex h-full w-full items-center justify-center">
+    <div className="flex h-full w-full justify-center">
       <Document
         file={url}
         loading={null}
+        onLoadSuccess={({ numPages }) => {
+          setNumPages(numPages);
+          setError(null);
+        }}
         onLoadError={(error) => {
           console.error("[ERROR]: Error loading PDF:", error);
           // Send the error to Sentry
@@ -51,16 +58,18 @@ const PDFViewer = ({ url, width }: { url: string | null; width: number }) => {
 
           // retry converting the pdf to blob
         }}
-        className="scroll-bar-hidden dark:bg-background flex h-full max-h-full w-full items-center justify-center overflow-y-scroll py-[18px] sm:items-start"
+        className="scroll-bar-hidden dark:bg-background flex h-full max-h-full w-full flex-col items-center gap-4 overflow-y-scroll py-[18px]"
       >
-        {!error && (
-          <Page
-            pageNumber={1}
-            width={width > 600 ? 600 - PDF_VIEWER_PADDING : width - PDF_VIEWER_PADDING}
-            renderTextLayer={false}
-            renderAnnotationLayer={false}
-          />
-        )}
+        {!error &&
+          Array.from({ length: numPages }, (_, index) => (
+            <Page
+              key={`page_${index + 1}`}
+              pageNumber={index + 1}
+              width={pageWidth}
+              renderTextLayer={false}
+              renderAnnotationLayer={false}
+            />
+          ))}
       </Document>
     </div>
   );

--- a/apps/web/src/components/pdf/default.tsx
+++ b/apps/web/src/components/pdf/default.tsx
@@ -174,6 +174,7 @@ const DefaultPDF: React.FC<{ data: ZodCreateInvoiceSchema }> = ({ data }) => {
         {/* Items Table */}
         <View style={tw("mt-5 grow")}>
           <View
+            fixed
             style={[
               tw(
                 cn(
@@ -192,6 +193,7 @@ const DefaultPDF: React.FC<{ data: ZodCreateInvoiceSchema }> = ({ data }) => {
             {data.items.map((item, index) => (
               <View
                 key={index}
+                wrap={false}
                 style={tw(
                   cn(
                     "flex-row p-2 text-2xs rounded",
@@ -221,7 +223,7 @@ const DefaultPDF: React.FC<{ data: ZodCreateInvoiceSchema }> = ({ data }) => {
           </View>
         </View>
         {/* Invoice meta data and pricing */}
-        <View style={tw("flex flex-row gap-[50px]")}>
+        <View wrap={false} style={tw("flex flex-row gap-[50px]")}>
           <View style={tw("flex flex-col gap-[15px] justify-end w-1/2")}>
             {/* Payment Information */}
             {data.metadata.paymentInformation.length ? (

--- a/apps/web/src/components/pdf/vercel.tsx
+++ b/apps/web/src/components/pdf/vercel.tsx
@@ -148,8 +148,13 @@ const VercelPdf: React.FC<{ data: ZodCreateInvoiceSchema }> = ({ data }) => {
         {/* Items Table */}
         <View style={tw("grow")}>
           <View
+            fixed
             style={[
-              tw(cn("flex-row flex items-center px-4 py-2.5 text-sm text-neutral-100 border-b border-borderColor")),
+              tw(
+                cn(
+                  "flex-row flex items-center px-4 py-2.5 text-sm text-neutral-100 border-b border-borderColor bg-background",
+                ),
+              ),
             ]}
           >
             <Text style={tw("w-[60%]")}>Item</Text>
@@ -161,6 +166,7 @@ const VercelPdf: React.FC<{ data: ZodCreateInvoiceSchema }> = ({ data }) => {
             {data.items.map((item, index) => (
               <View
                 key={index}
+                wrap={false}
                 style={tw(
                   cn(
                     "flex-row px-4 py-3 text-2xs border-b border-borderColor",
@@ -188,7 +194,7 @@ const VercelPdf: React.FC<{ data: ZodCreateInvoiceSchema }> = ({ data }) => {
           </View>
         </View>
         {/* Invoice meta data and pricing */}
-        <View style={tw("flex flex-row border-t border-borderColor")}>
+        <View wrap={false} style={tw("flex flex-row border-t border-borderColor")}>
           <View style={tw("flex flex-col w-1/2 border-r border-borderColor")}>
             {/* Payment Information */}
             {data.metadata.paymentInformation.length ? (


### PR DESCRIPTION
## Summary

Long invoices used to overflow a single A4 page with no supervision — rows were cut mid-row, the items table header didn't repeat on continuation pages, and the live preview only ever showed page 1. This makes multi-page invoices render cleanly in both the PDF and the preview.

- **Repeat the items table header** on every page (`fixed`) so continuation pages stay readable — applied to both `default` and `vercel` templates.
- **Stop rows from splitting** across a page break (`wrap={false}` on each item row).
- **Keep the metadata + pricing block intact** as one unit (`wrap={false}`) so the totals land on the **last page only** instead of splitting mid-section.
- **Preview shows every page**: `PDFViewer` now reads `numPages` from the document's `onLoadSuccess` and renders all pages stacked vertically and scrollable, mirroring the PDF (previously hard-coded to `pageNumber={1}`).

Closes #67
Closes #68

## Test plan
- [ ] Open `/create/invoice` and add ~20+ items so the invoice overflows one page.
- [ ] Preview: pages stack vertically and scroll; the `Item / Qty / Price / Total` header repeats atop each page; no row is cut mid-row; the totals block appears only on the last page.
- [ ] Toggle the theme template between **default** and **vercel** — both paginate cleanly.
- [ ] A 1–2 item invoice is unchanged (single page, totals anchored at the bottom).
- [ ] Download the PDF and confirm it matches the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)